### PR TITLE
Trust proxies

### DIFF
--- a/src/Web/RequestFactory.php
+++ b/src/Web/RequestFactory.php
@@ -2,37 +2,53 @@
 
 namespace GMO\Common\Web;
 
-class RequestFactory {
+class RequestFactory
+{
+    protected $options = array();
 
-	/**
-	 * Registers this as the factory to use when creating requests.
-	 */
-	public static function register() {
-		Request::setFactory(array(get_called_class(), 'factory'));
-	}
+    /**
+     * Constructor.
+     *
+     * @param array $options
+     */
+    public function __construct(array $options = array())
+    {
+        $this->options = $options;
+    }
 
-	/**
-	 * Creates a new request with the given parameters.
-	 *
-	 * @param array $query
-	 * @param array $request
-	 * @param array $attributes
-	 * @param array $cookies
-	 * @param array $files
-	 * @param array $server
-	 * @param null  $content
-	 *
-	 * @return Request
-	 */
-	public static function factory(
-		array $query = array(),
-		array $request = array(),
-		array $attributes = array(),
-		array $cookies = array(),
-		array $files = array(),
-		array $server = array(),
-		$content = null
-	) {
-		return new Request($query, $request, $attributes, $cookies, $files, $server, $content);
-	}
+    /**
+     * Registers this as the factory to use when creating requests.
+     *
+     * @param array $options
+     */
+    public static function register($options = array())
+    {
+        $factory = new static($options);
+        Request::setFactory(array($factory, 'createRequest'));
+    }
+
+    /**
+     * Creates a new request with the given parameters.
+     *
+     * @param array           $query
+     * @param array           $request
+     * @param array           $attributes
+     * @param array           $cookies
+     * @param array           $files
+     * @param array           $server
+     * @param string|resource $content
+     *
+     * @return Request
+     */
+    public function createRequest(
+        array $query = array(),
+        array $request = array(),
+        array $attributes = array(),
+        array $cookies = array(),
+        array $files = array(),
+        array $server = array(),
+        $content = null
+    ) {
+        return new Request($query, $request, $attributes, $cookies, $files, $server, $content);
+    }
 }

--- a/src/Web/RequestFactory.php
+++ b/src/Web/RequestFactory.php
@@ -13,6 +13,9 @@ class RequestFactory
      */
     public function __construct(array $options = array())
     {
+        $options += array(
+            'trust_proxies' => true,
+        );
         $this->options = $options;
     }
 
@@ -49,6 +52,16 @@ class RequestFactory
         array $server = array(),
         $content = null
     ) {
-        return new Request($query, $request, $attributes, $cookies, $files, $server, $content);
+        $request = new Request($query, $request, $attributes, $cookies, $files, $server, $content);
+
+        $proxies = $this->options['trust_proxies'];
+        if ($proxies === true) {
+            $proxies = array('127.0.0.1', $request->server->get('REMOTE_ADDR'));
+        }
+        if ($proxies === false) {
+            Request::setTrustedProxies((array) $proxies);
+        }
+
+        return $request;
     }
 }


### PR DESCRIPTION
Set `Request` to trust all IPs for proxies by default. Assuming the `RequestFactory` is `register`ed, `$request->getClientIp()` will return the correct IP address of the client not the ELB.

/cc @gmo/devs 