### PR TITLE
Added BaseUriPlugin for HTTPlug clients.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,15 @@
         "webmozart/path-util": "^2.3"
     },
     "require-dev": {
+        "guzzlehttp/psr7": "^1.4",
         "monolog/monolog": "^1.18",
         "phpunit/phpunit": "^6.2",
+        "php-http/client-common": "^1.5",
+        "php-http/discovery": "^1.2",
+        "php-http/message": "^1.5",
+        "php-http/message-factory": "^1.0",
         "predis/predis": "^1.0",
+        "psr/http-message": "^1.0",
         "psr/log": "1.0.0",
         "symfony/phpunit-bridge": "^2.8 || ^3.0"
     },

--- a/src/Http/Plugin/BaseUriPlugin.php
+++ b/src/Http/Plugin/BaseUriPlugin.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Gmo\Common\Http\Plugin;
+
+use Http\Client\Common\Plugin;
+use Http\Client\Common\Plugin\AddHostPlugin;
+use Http\Discovery\UriFactoryDiscovery;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\UriInterface;
+
+/**
+ * Add base uri to a request. Useful for base API URLs like http://domain.com/api.
+ *
+ * This uses Guzzle logic for base path concatenation. If the request path starts
+ * with a "/" then the base path is not prepended.
+ */
+final class BaseUriPlugin implements Plugin
+{
+    /** @var AddHostPlugin */
+    private $addHostPlugin;
+    /** @var UriInterface|null */
+    private $uri;
+
+    /**
+     * @param string|UriInterface $uri        Has to contain a host name and cans have a path.
+     * @param array               $hostConfig Config for AddHostPlugin. @see AddHostPlugin::configureOptions
+     */
+    public function __construct($uri, array $hostConfig = [])
+    {
+        if (is_string($uri)) {
+            $uri = UriFactoryDiscovery::find()->createUri($uri);
+        }
+
+        $this->addHostPlugin = new AddHostPlugin($uri, $hostConfig);
+
+        if (rtrim($uri->getPath(), '/')) {
+            if (substr($uri->getPath(), -1) === '/') {
+                $uri = $uri->withPath(substr($uri->getPath(), 0, -1));
+            }
+
+            $this->uri = $uri;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleRequest(RequestInterface $request, callable $next, callable $first)
+    {
+        $path = $request->getUri()->getPath();
+        if ($this->uri && strpos($path, '/') !== 0) {
+            if ($path) {
+                $path = '/' . $path;
+            }
+            $path = $this->uri->getPath() . $path;
+
+            $request = $request->withUri($request->getUri()->withPath($path));
+        }
+
+        return $this->addHostPlugin->handleRequest($request, $next, $first);
+    }
+}

--- a/tests/Http/Plugin/BaseUriPluginTest.php
+++ b/tests/Http/Plugin/BaseUriPluginTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Gmo\Common\Tests\Http\Plugin;
+
+use Gmo\Common\Http\Plugin\BaseUriPlugin;
+use Http\Client\Common\Plugin;
+use Http\Discovery\MessageFactoryDiscovery;
+use Http\Discovery\UriFactoryDiscovery;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+class BaseUriPluginTest extends TestCase
+{
+    public function testCreationWithUri()
+    {
+        $uri = UriFactoryDiscovery::find()->createUri('http://example.com/api');
+        $plugin = new BaseUriPlugin($uri);
+
+        $this->assertInstanceOf(Plugin::class, $plugin);
+    }
+
+    public function testCreationWithString()
+    {
+        $plugin = new BaseUriPlugin('http://example.com/api');
+
+        $this->assertInstanceOf(Plugin::class, $plugin);
+    }
+
+    public function provideUris()
+    {
+        return [
+            'relative path appends to base path' => [
+                'http://example.com:8000/api',
+                'foo',
+                'http://example.com:8000/api/foo',
+            ],
+            'absolute path replaces base path' => [
+                'http://example.com:8000/api',
+                '/foo',
+                'http://example.com:8000/foo',
+            ],
+            'empty path' => [
+                'http://example.com:8000/api',
+                '',
+                'http://example.com:8000/api',
+            ],
+            'base path with trailing slash' => [
+                'http://example.com:8000/api/',
+                '',
+                'http://example.com:8000/api',
+            ],
+            'empty base path' => [
+                'http://example.com:8000',
+                '/foo',
+                'http://example.com:8000/foo',
+            ],
+            'base path is slash' => [
+                'http://example.com:8000/',
+                '/foo',
+                'http://example.com:8000/foo',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideUris
+     */
+    public function testHandleRequest($baseUri, $requestUri, $resultUri)
+    {
+        $plugin = new BaseUriPlugin($baseUri);
+
+        $request = MessageFactoryDiscovery::find()->createRequest('GET', $requestUri);
+
+        /** @var RequestInterface $result */
+        $result = $plugin->handleRequest($request, function ($request) { return $request; }, function () {});
+
+        $this->assertEquals($resultUri, (string) $result->getUri());
+    }
+}


### PR DESCRIPTION
It uses Guzzle logic for base path concatenation. If the request path starts with a "/" then the base path is not prepended.

It also allows the base uri to be a string as a shortcut.