### PR TITLE
Added SafeCache and SafeSimpleCache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ services:
 
 before_install:
   # Remove bolt/collection for PHP 5.3/5.4 since it requires PHP 5.5
-  - if [[ $TRAVIS_PHP_VERSION = '5.3' || $TRAVIS_PHP_VERSION = '5.4' ]]; then composer remove bolt/collection --dev --no-update; fi
+  - if [[ $TRAVIS_PHP_VERSION = '5.3' || $TRAVIS_PHP_VERSION = '5.4' ]]; then composer remove bolt/collection symfony/cache --dev --no-update; fi
 
 install:
   - composer install

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "monolog/monolog": "^1.18",
         "phpunit/phpunit": "^4.8",
         "predis/predis": "^1.0",
+        "symfony/cache": "^3.0",
         "psr/log": "^1.0",
         "silex/silex": "1.3.*@dev",
         "symfony/phpunit-bridge": "^2.8 || ^3.0",

--- a/src/Cache/SafeCache.php
+++ b/src/Cache/SafeCache.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace Gmo\Common\Cache;
+
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Psr\Cache\InvalidArgumentException;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Symfony\Component\Cache\Adapter\NullAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+
+/**
+ * Wraps a PSR-6 Cache implementation and swallows all runtime exceptions (optionally logging them).
+ */
+class SafeCache implements CacheItemPoolInterface, LoggerAwareInterface, TagAwareAdapterInterface
+{
+    /** @var CacheItemPoolInterface */
+    protected $cache;
+    /** @var bool */
+    protected $debug;
+    /** @var LoggerInterface */
+    protected $logger;
+    /** @var CacheItemPoolInterface */
+    protected $nullCache;
+
+    /**
+     * Constructor.
+     *
+     * @param CacheItemPoolInterface $cache
+     * @param bool                   $debug
+     * @param LoggerInterface        $logger
+     */
+    public function __construct(CacheItemPoolInterface $cache, $debug = false, LoggerInterface $logger = null)
+    {
+        $this->cache = $cache;
+        $this->debug = $debug;
+        $this->logger = $logger ?: new NullLogger();
+        if (!$debug) {
+            $this->nullCache = new NullAdapter();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+        if ($this->cache instanceof LoggerAwareInterface) {
+            $this->cache->setLogger($logger);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItem($key)
+    {
+        try {
+            return $this->cache->getItem($key);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to get the cache item.', array(
+                'key'       => $key,
+                'exception' => $e,
+            ));
+        }
+
+        return $this->nullCache->getItem($key);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getItems(array $keys = array())
+    {
+        try {
+            return $this->cache->getItems($keys);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to get the cache items.', array(
+                'keys'       => $keys,
+                'exception' => $e,
+            ));
+        }
+
+        return $this->nullCache->getItems($keys);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasItem($key)
+    {
+        try {
+            return $this->cache->hasItem($key);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to check if cache has the item.', array(
+                'key'       => $key,
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        try {
+            return $this->cache->clear();
+        } catch (\Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to clear the cache.', array(
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItem($key)
+    {
+        try {
+            return $this->cache->deleteItem($key);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to delete the cache item.', array(
+                'key'       => $key,
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteItems(array $keys)
+    {
+        try {
+            return $this->cache->deleteItems($keys);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to delete the cache items.', array(
+                'keys'      => $keys,
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function save(CacheItemInterface $item)
+    {
+        try {
+            return $this->cache->save($item);
+        } catch (\Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to save the cache item.', array(
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveDeferred(CacheItemInterface $item)
+    {
+        try {
+            return $this->cache->saveDeferred($item);
+        } catch (\Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to defer saving of the cache item.', array(
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function commit()
+    {
+        try {
+            return $this->cache->commit();
+        } catch (\Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to save deferred cache items.', array(
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function invalidateTags(array $tags)
+    {
+        if (!$this->cache instanceof TagAwareAdapterInterface) {
+            throw new \LogicException('Given cache does not implement Symfony\Component\Cache\Adapter\TagAwareAdapterInterface');
+        }
+
+        try {
+            return $this->cache->invalidateTags($tags);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (\Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to invalidate the tags.', array(
+                'tags'      => $tags,
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+}

--- a/src/Cache/SafeSimpleCache.php
+++ b/src/Cache/SafeSimpleCache.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace Gmo\Common\Cache;
+
+use Exception;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Psr\SimpleCache\CacheInterface;
+use Psr\SimpleCache\InvalidArgumentException;
+
+/**
+ * Wraps a PSR-16 Simple Cache implementation and swallows all runtime exceptions (optionally logging them).
+ */
+class SafeSimpleCache implements CacheInterface, LoggerAwareInterface
+{
+    /** @var CacheInterface */
+    protected $cache;
+    /** @var bool */
+    protected $debug;
+    /** @var LoggerInterface */
+    protected $logger;
+
+    /**
+     * Constructor.
+     *
+     * @param CacheInterface  $cache
+     * @param bool            $debug
+     * @param LoggerInterface $logger
+     */
+    public function __construct(CacheInterface $cache, $debug = false, LoggerInterface $logger = null)
+    {
+        $this->cache = $cache;
+        $this->debug = $debug;
+        $this->logger = $logger ?: new NullLogger();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setLogger(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+        if ($this->cache instanceof LoggerAwareInterface) {
+            $this->cache->setLogger($logger);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($key, $default = null)
+    {
+        try {
+            return $this->cache->get($key);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to get the cache item.', array(
+                'key'       => $key,
+                'exception' => $e,
+            ));
+
+            return $default;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($key, $value, $ttl = null)
+    {
+        try {
+            return $this->cache->set($key, $value, $ttl);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to set the cache item.', array(
+                'key'       => $key,
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function delete($key)
+    {
+        try {
+            return $this->cache->delete($key);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to delete the cache item.', array(
+                'key'       => $key,
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function clear()
+    {
+        try {
+            return $this->cache->clear();
+        } catch (Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to clear the cache.', array(
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getMultiple($keys, $default = null)
+    {
+        try {
+            return $this->cache->getMultiple($keys);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to get the cache items.', array(
+                'keys'      => $keys,
+                'exception' => $e,
+            ));
+
+            return array_fill_keys($keys, $default);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setMultiple($values, $ttl = null)
+    {
+        try {
+            return $this->cache->setMultiple($values, $ttl);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to set the cache items.', array(
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deleteMultiple($keys)
+    {
+        try {
+            return $this->cache->deleteMultiple($keys);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed to delete the cache items.', array(
+                'keys'      => $keys,
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($key)
+    {
+        try {
+            return $this->cache->has($key);
+        } catch (InvalidArgumentException $e) {
+            throw $e;
+        } catch (Exception $e) {
+            if ($this->debug) {
+                throw $e;
+            }
+            $this->logger->error('Failed check if the cache has the item.', array(
+                'key'       => $key,
+                'exception' => $e,
+            ));
+
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
These wrap their respective interfaces and swallow / log all runtime exceptions.

We currently have this in GodLife for Doctrine. Currently it's only used for device detection cache.
We were having problems with Redis throwing errors, and since it was just to speed up processing we were ok to continue with out the cache layer.

Happy to talk through whether this is needed or another way to solve this problem. Maybe it's not needed with Symfony's implementation?